### PR TITLE
allow for both forms of true/false booleans in args

### DIFF
--- a/lib/puppet/provider/cpanm/default.rb
+++ b/lib/puppet/provider/cpanm/default.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:cpanm).provide(:default) do
       options << "-f"
     end
 
-    if @resource[:test] == :false || @resource[:test] = false
+    if @resource[:test] == :false || @resource[:test] == false
       options << "-n"
     end
 

--- a/lib/puppet/provider/cpanm/default.rb
+++ b/lib/puppet/provider/cpanm/default.rb
@@ -48,11 +48,11 @@ Puppet::Type.type(:cpanm).provide(:default) do
       options << @resource[:mirror]
     end
 
-    if @resource[:force] == :true
+    if @resource[:force] == :true || @resource[:force] == true
       options << "-f"
     end
 
-    if @resource[:test] == :false
+    if @resource[:test] == :false || @resource[:test] = false
       options << "-n"
     end
 


### PR DESCRIPTION
puppet 5.5 uses `true` and `false` rather than `:true` and `:false`.

Fixes #8